### PR TITLE
Add OSX Build for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      # addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      os: osx
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,10 @@ before_install:
   - "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/local/bin:$PATH"
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
-  - if [ `uname` = "Darwin" ]
+  - |
+    if [ `uname` = "Darwin" ]
     then
-      brew install ghc cabal-install
+      brew install gcc48 ghc cabal-install
     fi
   - echo $(ghc --version)
   - echo $(cabal --version)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-    - compiler: "ghc"
+    - compiler: "ghc-8.4.3 (osx)"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       # addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       os: osx
@@ -57,7 +57,7 @@ before_install:
   - |
     if [ `uname` = "Darwin" ]
     then
-      brew install gcc48 ghc cabal-install
+      brew install gcc@4.9 ghc@8.4 cabal-install
     fi
   - echo $(ghc --version)
   - echo $(cabal --version)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,13 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+
     - compiler: "ghc-8.4.3 (osx)"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      # addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       os: osx
+
+  allow_failures:
+    - os: osx
 
 before_install:
   - HC=${CC}
@@ -55,7 +58,7 @@ before_install:
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
   - |
-    if [ `uname` = "Darwin" ]
+    if [ "$TRAVIS_OS_NAME" == "osx" ]
     then
       brew install ghc@8.4 cabal-install
       HC=ghc

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,10 @@ before_install:
   - |
     if [ `uname` = "Darwin" ]
     then
-      brew install gcc@4.9 ghc@8.4 cabal-install
+      brew install ghc@8.4 cabal-install
+      HC=ghc
+      HCPKG=${HC/ghc/ghc-pkg}
+      HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
     fi
   - echo $(ghc --version)
   - echo $(cabal --version)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.1"
+    - compiler: "ghc"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       # addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       os: osx
@@ -54,6 +54,12 @@ before_install:
   - "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/local/bin:$PATH"
   - HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
   - echo $HCNUMVER
+  - if [ `uname` = "Darwin" ]
+    then
+      brew install ghc cabal-install
+    fi
+  - echo $(ghc --version)
+  - echo $(cabal --version)
 
 install:
   - cabal --version


### PR DESCRIPTION
There was no attempts to build this package on OSX so a critical failure to build was missed. That issue is being fixed in #18 . This PR enables an `allow_failure` build on OSX with GHC 8.4.3, but it means it is not a blind spot any more, at least.

I haven't squished these commits because we can do that on merge if people are happy with this change.